### PR TITLE
Drop acl dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "acl-sys"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbc079f9bdd3124fd18df23c67f7e0f79d24751ae151dcffd095fcade07a3eb2"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,7 +40,6 @@ dependencies = [
  "input-linux-sys",
  "libc",
  "nix",
- "posix-acl",
  "udev",
 ]
 
@@ -127,16 +117,6 @@ name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
-
-[[package]]
-name = "posix-acl"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9928b761309e4a4ca4f2d90eb03029142e3f7164107e18db4d46516515b87441"
-dependencies = [
- "acl-sys",
- "libc",
-]
 
 [[package]]
 name = "udev"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,3 @@ input-linux = "0.7"
 input-linux-sys = "0.9"
 nix = { version = "0.29", features = ["event", "socket", "user"] }
 libc = "0.2"
-posix-acl = "1"


### PR DESCRIPTION
It's not packaged in Fedora, has like 6 stars on github and doesn't seem to have any activity. https://xkcd.com/2347/ problem - let's just use the shell version, it's really not the end of the world.